### PR TITLE
fix: show username error

### DIFF
--- a/src/i18n/locales/en/default.json
+++ b/src/i18n/locales/en/default.json
@@ -208,6 +208,7 @@
     },
     "register": {
       "title": "Register",
+      "usernameInUse": "The username is already used",
       "emailInUse": "The email is already used",
       "passwordsDontMatch": "The passwords are not the same",
       "alreadyHaveAccount": "Already have an account?"

--- a/src/screens/Register/Register.jsx
+++ b/src/screens/Register/Register.jsx
@@ -100,13 +100,12 @@ const Register = ({ image }) => {
         .catch((error) => {
           if (error.response?.status === 409) {
             setServerError(false);
-            error.response.data.fields.map((elem) => {
+            error.response.data.fields.forEach((elem) => {
               if (elem.field === "username") {
                 setUsernameIsUsed(true);
               } else if (elem.field === "email") {
                 setEmailIsUsed(true);
               }
-              return;
             });
             return;
           }

--- a/src/screens/Register/Register.jsx
+++ b/src/screens/Register/Register.jsx
@@ -29,6 +29,7 @@ const Register = ({ image }) => {
   const [passwordRepeat, setPasswordRepeat] = useState("");
   const [serverAddressInput, setServerAddressInput] = useState(serverAddress);
   const [isSamePassword, setIsSamePassword] = useState(true);
+  const [usernameIsUsed, setUsernameIsUsed] = useState(false);
   const [emailIsUsed, setEmailIsUsed] = useState(false);
   const [serverError, setServerError] = useState(false);
   const [isServerValid, setIsServerValid] = useState(false);
@@ -99,7 +100,14 @@ const Register = ({ image }) => {
         .catch((error) => {
           if (error.response?.status === 409) {
             setServerError(false);
-            setEmailIsUsed(true);
+            error.response.data.fields.map((elem) => {
+              if (elem.field === "username") {
+                setUsernameIsUsed(true);
+              } else if (elem.field === "email") {
+                setEmailIsUsed(true);
+              }
+              return;
+            });
             return;
           }
 
@@ -170,11 +178,14 @@ const Register = ({ image }) => {
               placeholder={t("global.username")}
               autoComplete="current-password"
               onChange={(value) => {
+                setUsernameIsUsed(false);
                 setEmailIsUsed(false);
                 setServerError(false);
                 setUsername(value);
               }}
               value={username}
+              error={usernameIsUsed}
+              errorText={t("screens.register.usernameInUse")}
             />
             <TextInput
               required


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If there is no changelog entry, label this PR as trivial to bypass the Danger warning -->

| Status  | Type  |
| :---: | :---: |
| :white_check_mark: Ready | Hotfix |

## Description

The register screen will now handle duplicate username errors.
Right now, only one error ist shown, which is because of the server not sending two errors at the same time. **Will be fixed in later Versions**
<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots / GIFs (if appropriate):
<!--- Bonus points for GIFS --->
![Unbenannt](https://user-images.githubusercontent.com/54618409/119325515-3ae7b980-bc81-11eb-88ba-e81462112cb4.PNG)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I have considered the accessibility of my changes (i.e. did I add proper content descriptions to images, or run my changes with talkback enabled?)
- [x] I have documented my code if needed

## Resolves

<!-- List the issues that will be closed by this PR in the following format -->
<!-- resolves AN-123 -->
<!-- This will ensure that they are automatically closed once the PR is merged -->
